### PR TITLE
fix(fgh): convert --body-file/-F to --body with file content

### DIFF
--- a/fgh
+++ b/fgh
@@ -257,8 +257,55 @@ main() {
         return 1
     fi
 
+    # --body-file / -F をファイル内容に変換（fgp 側にファイルがないため）
+    local args=()
+    local skip_next=false
+    for ((i=1; i<=$#; i++)); do
+        if $skip_next; then
+            skip_next=false
+            continue
+        fi
+        local arg="${!i}"
+        local next_i=$((i + 1))
+        local next_arg="${!next_i}"
+
+        if [[ "$arg" == "--body-file" || "$arg" == "-F" ]]; then
+            if [[ -z "$next_arg" ]]; then
+                echo "Error: $arg requires a file path" >&2
+                return 1
+            fi
+            if [[ ! -f "$next_arg" ]]; then
+                echo "Error: File not found: $next_arg" >&2
+                return 1
+            fi
+            local content
+            content=$(cat "$next_arg")
+            args+=("--body" "$content")
+            skip_next=true
+        elif [[ "$arg" =~ ^--body-file=(.+)$ ]]; then
+            local filepath="${BASH_REMATCH[1]}"
+            if [[ ! -f "$filepath" ]]; then
+                echo "Error: File not found: $filepath" >&2
+                return 1
+            fi
+            local content
+            content=$(cat "$filepath")
+            args+=("--body" "$content")
+        elif [[ "$arg" =~ ^-F(.+)$ ]]; then
+            local filepath="${BASH_REMATCH[1]}"
+            if [[ ! -f "$filepath" ]]; then
+                echo "Error: File not found: $filepath" >&2
+                return 1
+            fi
+            local content
+            content=$(cat "$filepath")
+            args+=("--body" "$content")
+        else
+            args+=("$arg")
+        fi
+    done
+
     # pr create の場合、--head を自動付与（fgp 側で origin 解決できないため）
-    local args=("$@")
     if [[ "${args[0]}" == "pr" && "${args[1]}" == "create" ]]; then
         # --head が既に指定されているかチェック
         local has_head=false


### PR DESCRIPTION
## Summary
Read file content on devcontainer side and pass via `--body` instead of `--body-file`.

## Problem
`--body-file` points to a file on devcontainer, but fgp executes gh subprocess on host where that file doesn't exist.

## Solution
In fgh, detect `--body-file` / `-F` options, read the file locally, and replace with `--body <content>`.

Handles all variants:
- `--body-file <path>`
- `--body-file=<path>`
- `-F <path>`
- `-F<path>`

Closes #9