### PR TITLE
fix(fgh): output stderr on success (gh CLI convention)

### DIFF
--- a/fgh
+++ b/fgh
@@ -91,7 +91,9 @@ call_proxy_cli() {
     if [[ -n "$stderr" ]]; then
         echo "$stderr" >&2
     fi
-    echo "$stdout"
+    if [[ -n "$stdout" ]]; then
+        echo "$stdout"
+    fi
 }
 
 # sub-issue コマンドのヘルプ


### PR DESCRIPTION
## Summary
Output stderr on success to show gh CLI's human-readable messages.

## Problem
gh CLI outputs success messages like `✓ Closed issue...` to stderr (UNIX convention), but fgh was ignoring stderr on success.

## Fix
```bash
# gh outputs success messages to stderr (UNIX convention)
if [[ -n "$stderr" ]]; then
    echo "$stderr" >&2
fi
```

## Test
```bash
$ fgh issue reopen 15 && fgh issue close 15
✓ Reopened issue carrotRakko/github-finest-grained-permission-proxy#15 (Test close output)
✓ Closed issue carrotRakko/github-finest-grained-permission-proxy#15 (Test close output)
```

Closes #16