### PR TITLE
fix(fgp): add GH_FORCE_TTY and NO_COLOR for readable output

### DIFF
--- a/main.py
+++ b/main.py
@@ -704,6 +704,7 @@ class GitHubProxyHandler(BaseHTTPRequestHandler):
                 "GH_TOKEN": pat,
                 "GH_HOST": "github.com",
                 "GH_FORCE_TTY": "1",
+                "NO_COLOR": "1",
             }
         )
 


### PR DESCRIPTION
## Summary
Add `GH_FORCE_TTY=1` and `NO_COLOR=1` to gh subprocess environment.

## Problem
gh CLI suppresses human-readable messages (like `✓ Merged...`) when running without a TTY. Since fgp runs gh via subprocess, these messages were missing.

## Fix
- `GH_FORCE_TTY=1`: Force terminal-style output even without TTY
- `NO_COLOR=1`: Suppress ANSI color escape codes

## Before
```
$ fgh pr merge 18 --squash
(no output)
```

## After
```
$ fgh pr merge 20 --squash
✓ Squashed and merged pull request carrotRakko/terachess#20 (test no color)
```