### PR TITLE
feat: Support JSON5 config format

### DIFF
--- a/fgp/core/policy.py
+++ b/fgp/core/policy.py
@@ -10,6 +10,8 @@ import re
 import sys
 from pathlib import Path
 
+import json5
+
 DEFAULT_CONFIG_PATH = Path.home() / ".config" / "github-proxy" / "config.json"
 DEFAULT_PORT = 8766
 
@@ -469,9 +471,9 @@ EOF""", file=sys.stderr)
 
     try:
         with open(config_path) as f:
-            config = json.load(f)
-    except json.JSONDecodeError as e:
-        print(f"Error: Invalid JSON in config file: {e}", file=sys.stderr)
+            config = json5.load(f)
+    except ValueError as e:
+        print(f"Error: Invalid JSON5 in config file: {e}", file=sys.stderr)
         sys.exit(1)
 
     if "classic_pat" not in config:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,4 +5,5 @@ description = "Add your description here"
 requires-python = ">=3.12"
 dependencies = [
     "graphql-core>=3.2.7",
+    "json5>=0.9.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -8,10 +8,14 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "graphql-core" },
+    { name = "json5" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "graphql-core", specifier = ">=3.2.7" }]
+requires-dist = [
+    { name = "graphql-core", specifier = ">=3.2.7" },
+    { name = "json5", specifier = ">=0.9.0" },
+]
 
 [[package]]
 name = "graphql-core"
@@ -20,4 +24,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ac/9b/037a640a2983b09aed4a823f9cf1729e6d780b0671f854efa4727a7affbe/graphql_core-3.2.7.tar.gz", hash = "sha256:27b6904bdd3b43f2a0556dad5d579bdfdeab1f38e8e8788e555bdcb586a6f62c", size = 513484, upload-time = "2025-11-01T22:30:40.436Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/14/933037032608787fb92e365883ad6a741c235e0ff992865ec5d904a38f1e/graphql_core-3.2.7-py3-none-any.whl", hash = "sha256:17fc8f3ca4a42913d8e24d9ac9f08deddf0a0b2483076575757f6c412ead2ec0", size = 207262, upload-time = "2025-11-01T22:30:38.912Z" },
+]
+
+[[package]]
+name = "json5"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/e8/a3f261a66e4663f22700bc8a17c08cb83e91fbf086726e7a228398968981/json5-0.13.0.tar.gz", hash = "sha256:b1edf8d487721c0bf64d83c28e91280781f6e21f4a797d3261c7c828d4c165bf", size = 52441, upload-time = "2026-01-01T19:42:14.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/9e/038522f50ceb7e74f1f991bf1b699f24b0c2bbe7c390dd36ad69f4582258/json5-0.13.0-py3-none-any.whl", hash = "sha256:9a08e1dd65f6a4d4c6fa82d216cf2477349ec2346a38fd70cc11d2557499fbcc", size = 36163, upload-time = "2026-01-01T19:42:13.962Z" },
 ]


### PR DESCRIPTION
## Summary

- Allow comments and trailing commas in config.json
- Uses `json5` library for parsing config file

## Supported features

- `//` single-line comments
- `/* */` multi-line comments  
- trailing commas
- unquoted keys
- single quotes
- and more (full JSON5 spec)

## Example

```json5
{
  "classic_pat": "ghp_xxx",
  "rules": [
    { "effect": "allow", "actions": ["*"], "repos": ["owner/repo"] },
    // temporarily disabled
    // { "effect": "allow", "actions": ["issues:write"], "repos": ["other/repo"] },
  ]
}
```

## Test plan

- [x] `fgh auth status` works with JSON5 config

---

✍️ **Author**: Claude Code (DevContainer) with osabe