### PR TITLE
refactor: replace discussions:read/write with Layer 1 actions

### DIFF
--- a/fgp/commands/discussion.py
+++ b/fgp/commands/discussion.py
@@ -7,19 +7,30 @@ gh CLI doesn't have `gh discussion` command, so this is a custom implementation.
 
 from ..core.graphql import execute_graphql, get_repository_id
 
-# Actions this module provides
+# Actions this module provides (Layer 1 only)
 ACTIONS = [
-    "discussions:read",
-    "discussions:write",
+    "discussions:list",
+    "discussions:get",
+    "discussions:create",
+    "discussions:update",
+    "discussions:comment_list",
+    "discussions:comment_add",
+    "discussions:comment_edit",
 ]
 
 # CLI command -> action mapping
 CLI_ACTIONS = {
-    "list": "discussions:read",
-    "view": "discussions:read",
-    "create": "discussions:write",
-    "edit": "discussions:write",
-    "comment": "discussions:write",
+    "list": "discussions:list",
+    "view": "discussions:get",
+    "create": "discussions:create",
+    "edit": "discussions:update",
+    "comment": None,  # Determined by subcommand
+}
+
+# Comment subcommand -> action mapping
+COMMENT_CLI_ACTIONS = {
+    "add": "discussions:comment_add",
+    "edit": "discussions:comment_edit",
 }
 
 
@@ -27,6 +38,17 @@ def get_action(subcmd: str | None, args: list[str]) -> tuple[str | None, str | N
     """Get action for discussion subcommand."""
     if subcmd is None:
         return None, None
+
+    # Handle comment subcommand specially
+    if subcmd == "comment":
+        if not args:
+            return None, None
+        # "comment edit <id>" -> comment_edit
+        # "comment <number>" -> comment_add (add comment to discussion)
+        if args[0] == "edit":
+            return "discussions:comment_edit", None
+        else:
+            return "discussions:comment_add", None
 
     action = CLI_ACTIONS.get(subcmd)
     return (action, None) if action else (None, None)

--- a/fgp/core/policy.py
+++ b/fgp/core/policy.py
@@ -121,7 +121,7 @@ GIT_ENDPOINT_ACTIONS = [
 ]
 
 GRAPHQL_MUTATION_ACTIONS = {
-    "addDiscussionComment": "discussions:write",
+    "addDiscussionComment": "discussions:comment_add",
 }
 
 # =============================================================================
@@ -206,6 +206,17 @@ def get_all_actions() -> list[str]:
     ]
     return base_actions + PR_LAYER1_ACTIONS + _COMMAND_ACTIONS
 
+# Discussion Layer 1 actions
+DISCUSSION_LAYER1_ACTIONS = [
+    "discussions:list",
+    "discussions:get",
+    "discussions:create",
+    "discussions:update",
+    "discussions:comment_list",
+    "discussions:comment_add",
+    "discussions:comment_edit",
+]
+
 # For backward compatibility
 ALL_ACTIONS = [
     "metadata:read",
@@ -214,10 +225,9 @@ ALL_ACTIONS = [
     "code:read", "code:write",
     "issues:read", "issues:write",
     "git:read", "git:write",
-    "discussions:read", "discussions:write",
     "subissues:list", "subissues:parent", "subissues:add", "subissues:remove", "subissues:reprioritize",
     "pr:read", "pr:create", "pr:write", "pr:merge", "pr:comment", "pr:review",
-] + PR_LAYER1_ACTIONS
+] + PR_LAYER1_ACTIONS + DISCUSSION_LAYER1_ACTIONS
 
 ACTION_CATEGORIES = {
     "metadata": ["metadata:read"],
@@ -227,7 +237,7 @@ ACTION_CATEGORIES = {
     "issues": ["issues:read", "issues:write"],
     "pr": ["pr:read", "pr:create", "pr:write", "pr:merge", "pr:comment", "pr:review"] + PR_LAYER1_ACTIONS,
     "git": ["git:read", "git:write"],
-    "discussions": ["discussions:read", "discussions:write"],
+    "discussions": DISCUSSION_LAYER1_ACTIONS,
     "subissues": ["subissues:list", "subissues:parent", "subissues:add", "subissues:remove", "subissues:reprioritize"],
 }
 


### PR DESCRIPTION
## Summary

- Remove `discussions:read` and `discussions:write` (Layer 2 bundles)
- Add Layer 1 actions: `discussions:list`, `discussions:get`, `discussions:create`, `discussions:update`, `discussions:comment_list`, `discussions:comment_add`, `discussions:comment_edit`
- Update `CLI_ACTIONS` mapping to use Layer 1 actions
- Update `get_action()` to handle comment subcommand branching

## Why Layer 1 only?

GitHub's Discussion permission model differs significantly from Issues/PRs:
- Read can create/comment
- Triage can delete
- etc.

Rather than creating potentially confusing Layer 2 bundles, we implement Layer 1 actions only and evaluate bundling needs through real-world usage.

## Test plan

- [ ] Restart proxy on host
- [ ] Test `fgh discussion list` with `discussions:list` permission
- [ ] Test `fgh discussion view` with `discussions:get` permission
- [ ] Test `fgh discussion create` with `discussions:create` permission

Closes #23 (partial - Layer 1 implementation, extended operations TBD)

---

✍️ **Author**: Claude Code (DevContainer) with osabe