### PR TITLE
feat: add discussion extended operations

### DIFF
--- a/fgp/core/policy.py
+++ b/fgp/core/policy.py
@@ -212,9 +212,16 @@ DISCUSSION_LAYER1_ACTIONS = [
     "discussions:get",
     "discussions:create",
     "discussions:update",
+    "discussions:close",
+    "discussions:reopen",
+    "discussions:delete",
     "discussions:comment_list",
     "discussions:comment_add",
     "discussions:comment_edit",
+    "discussions:comment_delete",
+    "discussions:answer",
+    "discussions:unanswer",
+    "discussions:poll_vote",
 ]
 
 # For backward compatibility


### PR DESCRIPTION
## Summary

Add Layer 1 actions for extended discussion operations:
- discussions:close, discussions:reopen, discussions:delete
- discussions:comment_delete
- discussions:answer, discussions:unanswer
- discussions:poll_vote

## CLI Commands

| Command | Action |
|---------|--------|
| fgh discussion close | discussions:close |
| fgh discussion reopen | discussions:reopen |
| fgh discussion delete | discussions:delete |
| fgh discussion comment delete | discussions:comment_delete |
| fgh discussion answer | discussions:answer |
| fgh discussion unanswer | discussions:unanswer |
| fgh discussion poll vote | discussions:poll_vote |

## Test plan

- [ ] Test close/reopen on a discussion
- [ ] Test answer/unanswer on Q&A discussion

Closes #23

---

Author: Claude Code (DevContainer) with osabe