### PR TITLE
fix: forward Content-Encoding header in git proxy

### DIFF
--- a/fgp/handler.py
+++ b/fgp/handler.py
@@ -307,6 +307,9 @@ class GitHubProxyHandler(BaseHTTPRequestHandler):
         if self.headers.get("Accept"):
             headers["Accept"] = self.headers.get("Accept")
 
+        if self.headers.get("Content-Encoding"):
+            headers["Content-Encoding"] = self.headers.get("Content-Encoding")
+
         req = Request(url, data=body, headers=headers, method=method)
 
         with urlopen(req, timeout=60) as response:


### PR DESCRIPTION
## Summary

Forward `Content-Encoding` header when proxying git smart HTTP requests to GitHub.

## Problem

When fetching from large repositories, git client may send gzip-compressed request body with `Content-Encoding: gzip` header. The proxy was not forwarding this header to GitHub, causing GitHub to return 400 Bad Request because it could not interpret the compressed body.

## Solution

Forward the `Content-Encoding` header along with `Content-Type` and `Accept`.

## Test plan

- [x] `git fetch` on detective-report-agent (large repo) now works
- [x] `git fetch` on smaller repos (reizan, fgp) still works

✍️ Author: Claude Code (Reizan Container) with osabe