### PR TITLE
feat: add --replace option to install.sh

### DIFF
--- a/fgh
+++ b/fgh
@@ -561,20 +561,40 @@ main() {
         return
     fi
 
-    # issue/pr の引数なし or --help は gh に直接流す
+    # issue/pr with no args or --help: show help
     if [[ "$subcommand" == "issue" || "$subcommand" == "pr" ]]; then
         local second_arg="$2"
+        local needs_help=false
         if [[ -z "$second_arg" || "$second_arg" == "--help" || "$second_arg" == "-h" ]]; then
-            gh "$subcommand" --help
+            needs_help=true
+        else
+            for arg in "$@"; do
+                if [[ "$arg" == "--help" || "$arg" == "-h" ]]; then
+                    needs_help=true
+                    break
+                fi
+            done
+        fi
+        if $needs_help; then
+            if [[ "$(basename "$0")" == "fgh" ]]; then
+                gh "$subcommand" --help
+            else
+                # Running as 'gh' (--replace mode): route help through proxy
+                local help_repo
+                help_repo=$(get_repo_from_args "$@")
+                if [[ -z "$help_repo" ]]; then
+                    help_repo=$(get_repo_from_git)
+                fi
+                if [[ -n "$help_repo" ]]; then
+                    call_proxy_cli "$help_repo" "$subcommand" "--help"
+                else
+                    echo "Usage: gh $subcommand <command> [flags]"
+                    echo ""
+                    echo "Run 'gh $subcommand <command> --help' in a git repository for detailed help."
+                fi
+            fi
             return
         fi
-        # Check for --help anywhere in args
-        for arg in "$@"; do
-            if [[ "$arg" == "--help" || "$arg" == "-h" ]]; then
-                gh "$subcommand" --help
-                return
-            fi
-        done
     fi
 
     # owner/repo を取得

--- a/install.sh
+++ b/install.sh
@@ -4,17 +4,44 @@
 #
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/carrotRakko/github-finest-grained-permission-proxy/main/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/carrotRakko/github-finest-grained-permission-proxy/main/install.sh | bash -s -- --replace
 #
 
 set -e
 
 FGH_URL="https://raw.githubusercontent.com/carrotRakko/github-finest-grained-permission-proxy/main/fgh"
 INSTALL_DIR="/usr/local/bin"
-FGH_PATH="${INSTALL_DIR}/fgh"
 
-echo "[fgh] Downloading fgh..."
-sudo curl -fsSL "${FGH_URL}" -o "${FGH_PATH}"
-sudo chmod +x "${FGH_PATH}"
+REPLACE=false
+for arg in "$@"; do
+    case "$arg" in
+        --replace) REPLACE=true ;;
+        *) echo "[fgh] Unknown option: $arg" >&2; exit 1 ;;
+    esac
+done
 
-echo "[fgh] Installed to ${FGH_PATH}"
-echo "[fgh] Done! Run 'fgh --help' to get started."
+if $REPLACE; then
+    TARGET_PATH="${INSTALL_DIR}/gh"
+
+    EXISTING_GH=$(which gh 2>/dev/null || true)
+    if [[ -n "$EXISTING_GH" && "$EXISTING_GH" != "$TARGET_PATH" ]]; then
+        echo "[fgh] Removing existing gh at ${EXISTING_GH}..."
+        sudo rm -f "${EXISTING_GH}"
+    fi
+
+    echo "[fgh] Installing as gh (replacing original)..."
+    sudo curl -fsSL "${FGH_URL}" -o "${TARGET_PATH}"
+    sudo chmod +x "${TARGET_PATH}"
+
+    echo "[fgh] Installed to ${TARGET_PATH}"
+    echo "[fgh] Done! 'gh' now routes through fgp proxy."
+else
+    TARGET_PATH="${INSTALL_DIR}/fgh"
+
+    echo "[fgh] Downloading fgh..."
+    sudo curl -fsSL "${FGH_URL}" -o "${TARGET_PATH}"
+    sudo chmod +x "${TARGET_PATH}"
+
+    echo "[fgh] Installed to ${TARGET_PATH}"
+    echo "[fgh] Done! Run 'fgh --help' to get started."
+fi


### PR DESCRIPTION
## Summary

- Add `--replace` option to `install.sh` that installs fgh as `/usr/local/bin/gh` instead of `/usr/local/bin/fgh`, replacing the original gh binary
- Fix infinite recursion in `fgh` script when running as `gh`: help requests for `issue`/`pr` subcommands now route through the proxy instead of calling `gh` directly (which would call itself)

## Usage

```bash
# Default (unchanged): install as fgh
curl -fsSL .../install.sh | bash

# Replace mode: install as gh
curl -fsSL .../install.sh | bash -s -- --replace
```

## Motivation

Containers (e.g. reizan-container) can use `gh` directly while all commands are transparently routed through the fgp proxy. No need to remember to use `fgh` instead of `gh`.

## Test plan

- [ ] `install.sh` without `--replace` still installs to `/usr/local/bin/fgh`
- [ ] `install.sh --replace` removes existing `gh` and installs to `/usr/local/bin/gh`
- [ ] `gh issue --help` in replace mode does not infinitely recurse
- [ ] `gh issue list` in replace mode works normally through proxy

✍️ Author: Claude Code (Reizan Container) with osabe